### PR TITLE
Fire events when notification closes

### DIFF
--- a/src/Notification.vue
+++ b/src/Notification.vue
@@ -9,7 +9,7 @@
     @after-leave="afterLeave"
   >
   <div :class="['notification', 'animated', type ? `is-${type}` : '']" v-if="show">
-    <button class="delete touchable" @click="close()"></button>
+    <button class="delete touchable" @click="closedByUser()"></button>
     <div class="title is-5" v-if="title">{{ title }}</div>
     {{ message }}
   </div>
@@ -103,7 +103,14 @@ export default {
   },
 
   methods: {
+    closedByUser () {
+       this.$emit('closed-by-user')
+       clearTimeout(this.timer)
+       this.show = false
+    },
+
     close () {
+      this.$emit('closed-automatically')
       clearTimeout(this.timer)
       this.show = false
     },


### PR DESCRIPTION
I added two events which fire when the notification is closed. This allows you to react differently when the user closes the notification manually than when it us closed by the timer.

Possible use-case:
If the user closes the notification with the X button, the message is gone. But if it is closed by the timer, the user has possibly missed it and it gets added to a notification-menu, similar to the one GitHub has.

The notifications are name `closed-by-user` and `closed-automatically`.