### PR TITLE
Allow for the message to be parsed as HTML

### DIFF
--- a/src/Notification.vue
+++ b/src/Notification.vue
@@ -11,7 +11,8 @@
   <div :class="['notification', 'animated', type ? `is-${type}` : '']" v-if="show">
     <button class="delete touchable" @click="closedByUser()"></button>
     <div class="title is-5" v-if="title">{{ title }}</div>
-    {{ message }}
+    <div v-if="html" v-html="message"></div>
+    <div v-else>{{ message }}</div>
   </div>
 </transition>
 </template>
@@ -36,7 +37,11 @@ export default {
     container: {
       type: String,
       default: '.notifications'
-    }
+    },
+    html: {
+      type: Boolean,
+      default: false
+    },
   },
 
   data () {


### PR DESCRIPTION
This allows passing in a message along the lines of `Something <br /> <u>Foo Bar</u>.` and have it render correctly.  
Added prop `html`, defaults to safe rendering.
Passing `false` to (or omitting) the `html` prop will function as it currently does.
Passing `true` to the `html` prop will render `message` as HTML.

Might be worth calling the prop `asHtml`?